### PR TITLE
Function cospi is mentioned in the docs but it does not exist on the source

### DIFF
--- a/docs/build_api.py
+++ b/docs/build_api.py
@@ -168,7 +168,6 @@ groups = {
             "ceil",
             "cos",
             "cosh",
-            "cospi",
             "erf",
             "erfc",
             "erfcinv",


### PR DESCRIPTION
I was looking for sincospi function and I found in the docs there is "cospi" but not "sinpi", so I looked at the source code and didn't find any reference to them except in [docs/build_api.py](https://github.com/KernelTuner/kernel_float/blob/c1d132fe988b8b37fc4f77b41113104f7a3cd95c/docs/build_api.py#L171).